### PR TITLE
Emol

### DIFF
--- a/back/infolica/views/facture_emolument.py
+++ b/back/infolica/views/facture_emolument.py
@@ -348,6 +348,16 @@ def emolument_affaire_delete_view(request):
     emolument_affaire_id = request.params['emolument_affaire_id'] if "emolument_affaire_id" in request.params else None
     affaire_id = request.params['affaire_id'] if "affaire_id" in request.params else None
 
+
+    # Remove from Emolument
+    records = request.dbsession.query(Emolument).filter(
+        Emolument.emolument_affaire_id == emolument_affaire_id
+    ).all()
+
+    for record in records:
+        request.dbsession.delete(record)
+
+
     # Remove from EmolumentAffaire
     record = request.dbsession.query(EmolumentAffaire).filter(
         EmolumentAffaire.id == emolument_affaire_id
@@ -360,15 +370,6 @@ def emolument_affaire_delete_view(request):
             CustomError.RECORD_WITH_ID_NOT_FOUND.format(EmolumentAffaire.__tablename__, emolument_affaire_id))
 
     request.dbsession.delete(record)
-
-    # Remove from Emolument
-    records = request.dbsession.query(Emolument).filter(
-        Emolument.emolument_affaire_id == emolument_affaire_id
-    ).all()
-
-    for record in records:
-        request.dbsession.delete(record)
-
 
     return Utils.get_data_save_response(Constant.SUCCESS_DELETE.format(Emolument.__tablename__))
 

--- a/front/src/components/Affaires/Facturation/Emoluments/Emoluments.vue
+++ b/front/src/components/Affaires/Facturation/Emoluments/Emoluments.vue
@@ -819,7 +819,6 @@ export default {
             if (response && response.data) {
               this.putEmolumentsDetail(this.form_general.id).then(response => {
                 if (response && response.data) {
-                  this.showEmolumentsDialog = false;
                   this.$root.$emit("ShowMessage", "Le formulaire a été enregistré correctement");
 
                   //Log edition facture
@@ -845,7 +844,6 @@ export default {
               let emolument_affaire_id = response.data.emolument_affaire_id;
               this.postEmolumentsDetail(emolument_affaire_id).then(response => {
                 if (response && response.data) {
-                  this.showEmolumentsDialog = false;
   
                   this.$root.$emit("ShowMessage", "Le formulaire a été enregistré correctement");
 

--- a/front/src/components/Affaires/Facturation/Emoluments/Emoluments.vue
+++ b/front/src/components/Affaires/Facturation/Emoluments/Emoluments.vue
@@ -590,7 +590,7 @@ export default {
         Number(this.total.montant_22pl);
 
       this.total.montant_travauxTerrain_total_zi =
-        Number(this.total.montant_travauxTerrain_total) * Number(this.form_general.zi);
+        this.round(Number(this.total.montant_travauxTerrain_total) * Number(this.form_general.zi));
 
       this.total.montant_travauxTerrain_batiment_total_f_somme =
         this.form_general.nb_batiments>0? this.round(Number(this.total.montant_travauxTerrain_batiment_total_f.reduce((a, b) => Number(a) + Number(b)))): 0;
@@ -826,7 +826,6 @@ export default {
 
                   this.postEmolumentAffaireRepartition(this.form_general.id);
                   // refresh emoluments_general_list
-                  this.getEmolumentsGeneral();
                   this.$root.$emit("searchAffaireFactures");
                   resolve(this.form_general.id);
 
@@ -852,7 +851,7 @@ export default {
                   
                   this.postEmolumentAffaireRepartition(emolument_affaire_id);
                   // refresh emoluments_general_list
-                  this.getEmolumentsGeneral();
+                  this.form_general.id = emolument_affaire_id;
                   this.$root.$emit("searchAffaireFactures");
                   resolve(emolument_affaire_id);
 


### PR DESCRIPTION
Ce pull request:

- [ ] laisse ouverte la boîte de saisie des émoluments après l'enregistrement. Il faut cliquer sur "fermer" ou en dehors du dialogue pour fermer
- [ ] corrige la suppression d'émolument
- [ ] corrige une erreur d'arrondi dans les montants
- [ ] enregistre la facture automatiquement sans ouvrir le dialogue de facture lors du transfert des montants dans la facture