### PR TITLE
Bugfix

### DIFF
--- a/front/src/components/Affaires/Preavis/preavis.html
+++ b/front/src/components/Affaires/Preavis/preavis.html
@@ -27,7 +27,6 @@
                                 <md-table-cell md-label="Réponse" md-sort-by="date_reponse" style="min-width: 100px;">{{ item.date_reponse | formatDate }}</md-table-cell>
                                 <md-table-cell md-label="Préavis" md-sort-by="preavis" style="min-width: 100px;">{{ item.preavis }}</md-table-cell>
                                 <md-table-cell md-label="Remarque" md-sort-by="remarque"  style="min-width: 1000px;">{{ item.remarque.length>250? item.remarque.substring(0, 250) + "...": item.remarque }}</md-table-cell>
-                                <!-- <md-table-cell md-label="Remarque" md-sort-by="remarque"  style="min-width: 1000px;">{{ item.remarque.substring(0, 250) }}{{ item.remarque.length>250? "...": "" }}</md-table-cell> -->
                                 <md-table-cell md-label="Actions" style="min-width: 200px;">
                                     <md-button class="md-icon-button md-primary md-dense" v-on:click.prevent.stop="onModifyPreavis(item)" title="Mettre à jour le préavis" v-if="!affaireReadonly">
                                         <md-icon class="md-edit">edit</md-icon>

--- a/front/src/components/Affaires/Preavis/preavis.html
+++ b/front/src/components/Affaires/Preavis/preavis.html
@@ -27,7 +27,7 @@
                                 <md-table-cell md-label="Réponse" md-sort-by="date_reponse" style="min-width: 100px;">{{ item.date_reponse | formatDate }}</md-table-cell>
                                 <md-table-cell md-label="Préavis" md-sort-by="preavis" style="min-width: 100px;">{{ item.preavis }}</md-table-cell>
                                 <md-table-cell md-label="Remarque" md-sort-by="remarque"  style="min-width: 1000px;">{{ item.remarque }}</md-table-cell>
-                                <md-table-cell md-label="Actions" v-if="!affaireReadonly"  style="min-width: 200px;">
+                                <md-table-cell md-label="Actions" style="min-width: 200px;">
                                     <md-button class="md-icon-button md-primary md-dense" v-on:click.prevent.stop="onModifyPreavis(item)" title="Mettre à jour le préavis" v-if="!affaireReadonly">
                                         <md-icon class="md-edit">edit</md-icon>
                                     </md-button>

--- a/front/src/components/Affaires/Preavis/preavis.html
+++ b/front/src/components/Affaires/Preavis/preavis.html
@@ -26,7 +26,8 @@
                                 <md-table-cell md-label="Demande" md-sort-by="date_demande" style="min-width: 100px;">{{ item.date_demande | formatDate }}</md-table-cell>
                                 <md-table-cell md-label="Réponse" md-sort-by="date_reponse" style="min-width: 100px;">{{ item.date_reponse | formatDate }}</md-table-cell>
                                 <md-table-cell md-label="Préavis" md-sort-by="preavis" style="min-width: 100px;">{{ item.preavis }}</md-table-cell>
-                                <md-table-cell md-label="Remarque" md-sort-by="remarque"  style="min-width: 1000px;">{{ item.remarque }}</md-table-cell>
+                                <md-table-cell md-label="Remarque" md-sort-by="remarque"  style="min-width: 1000px;">{{ item.remarque.length>250? item.remarque.substring(0, 250) + "...": item.remarque }}</md-table-cell>
+                                <!-- <md-table-cell md-label="Remarque" md-sort-by="remarque"  style="min-width: 1000px;">{{ item.remarque.substring(0, 250) }}{{ item.remarque.length>250? "...": "" }}</md-table-cell> -->
                                 <md-table-cell md-label="Actions" style="min-width: 200px;">
                                     <md-button class="md-icon-button md-primary md-dense" v-on:click.prevent.stop="onModifyPreavis(item)" title="Mettre à jour le préavis" v-if="!affaireReadonly">
                                         <md-icon class="md-edit">edit</md-icon>


### PR DESCRIPTION
Affiche le bouton de génération du PDF des préavis même lorsque l'affaire est clôturée.
Ajoute les anciennes versions de préavis sur le PDF généré.
Pour un peu de cosmétique: affiche uniquement les 250 premiers caractères du préavis dans le tableau. Cliquer sur la ligne pour accéder au contenu entier.