### PR TITLE
Modif affaire

### DIFF
--- a/back/infolica/routes.py
+++ b/back/infolica/routes.py
@@ -36,6 +36,7 @@ def includeme(config):
     config.add_route('loadfile_bf_rp', '/infolica/api/loadfile_bf_rp')
     config.add_route('save_bf_rp', '/infolica/api/save_bf_rp')
     config.add_route('activer_affaire', '/infolica/api/activer_affaire')
+    config.add_route('affaire_cloture', '/infolica/api/affaire_cloture')
     #Factures
     config.add_route('factures', '/infolica/api/factures')
     config.add_route('factures_s', '/infolica/api/factures/')

--- a/back/infolica/scripts/utils.py
+++ b/back/infolica/scripts/utils.py
@@ -388,4 +388,36 @@ class Utils(object):
         
         return
 
+
+    @classmethod
+    def affaireUpdatePermission(cls, request, affaire_type):
+        permission = request.registry.settings['affaire_edition']
+
+        # Affaire de cadastration
+        if affaire_type == request.registry.settings['affaire_type_cadastration_id']:
+            permission = request.registry.settings['affaire_cadastration_edition']
+        # Affaire de PPE
+        elif affaire_type == request.registry.settings['affaire_type_ppe_id']:
+            permission = request.registry.settings['affaire_ppe_edition']
+        # Affaire de révision d'abornement
+        elif affaire_type == request.registry.settings['affaire_type_revision_abornement_id']:
+            permission = request.registry.settings['affaire_revision_abornement_edition']
+        # Affaire de rétablissement de PFP3
+        elif affaire_type == request.registry.settings['affaire_type_retablissement_pfp3_id']:
+            permission = request.registry.settings['affaire_retablissement_pfp3_edition']
+        # Affaire pcop
+        elif affaire_type == request.registry.settings['affaire_type_part_copropriete_id']:
+            permission = request.registry.settings['affaire_pcop_edition']
+        # Affaire mpd
+        elif affaire_type == request.registry.settings['affaire_type_mpd_id']:
+            permission = request.registry.settings['affaire_mpd_edition']
+        # Affaire autre
+        elif affaire_type == request.registry.settings['affaire_type_autre_id']:
+            permission = request.registry.settings['affaire_autre_edition']
+        # Affaire affaire_remaniement_parcellaire_id
+        elif affaire_type == request.registry.settings['affaire_remaniement_parcellaire_id']:
+            permission = request.registry.settings['affaire_remaniement_parcellaire_edition']
+
+        return permission
+
     

--- a/back/infolica/views/default.py
+++ b/back/infolica/views/default.py
@@ -27,6 +27,7 @@ def test_error(exc, request):
 @view_config(route_name='login_s', request_method='OPTIONS', renderer='json')
 @view_config(route_name='logout', request_method='OPTIONS', renderer='json')
 @view_config(route_name='affaires', request_method='OPTIONS', renderer='json')
+@view_config(route_name='affaire_cloture', request_method='OPTIONS', renderer='json')
 @view_config(route_name='affaires_s', request_method='OPTIONS', renderer='json')
 @view_config(route_name='recherche_clients', request_method='OPTIONS', renderer='json')
 @view_config(route_name='recherche_clients_s', request_method='OPTIONS', renderer='json')

--- a/front/.env
+++ b/front/.env
@@ -105,6 +105,7 @@ VUE_APP_AFFAIRES_COCKPIT_ENDPOINT = "/affaires_cockpit"
 VUE_APP_ABANDON_AFFAIRE_REOUVERTURE_AFFAIRE_PARENT_ENDPOINT = "/abandon_affaire_reopen_parent_affaire"
 VUE_APP_AFFAIRE_ATTRIBUTION_CHANGE_STATE_ENDPOINT = "/affaire_attribution_change_state"
 VUE_APP_ACTIVATE_AFFAIRE_ENDPOINT = "/activer_affaire"
+VUE_APP_AFFAIRE_CLOTURE_ENDPOINT = "/affaire_cloture"
 
 #Preavis
 VUE_APP_PREAVIS_ENDPOINT = "/preavis"

--- a/front/src/components/Affaires/NewAffaire/NewAffaire.vue
+++ b/front/src/components/Affaires/NewAffaire/NewAffaire.vue
@@ -1037,7 +1037,7 @@ export default {
         this.form.nom = modif_type;
         if (this.form.affaire_modif_type && this.form.affaire_modif_type.id === Number(process.env.VUE_APP_TYPE_MODIFICATION_RETABLISSEMENT_ETAT_JURIDIQUE_ID)) {
           this.form.nom = modif_type;
-          } else {
+        } else {
           this.form.nom = modif_type + this.selectedModificationAffaire.nom;
         }
         this.form.nom_ = this.selectedModificationAffaire.nom; // garder le nom pas modifié en mémoire
@@ -1301,8 +1301,6 @@ export default {
         } else {
           this.form.nom = "Mise à jour périodique"; 
         }
-      } else {
-        this.form.nom = null;
       }
     }
 

--- a/front/src/components/Affaires/NewAffaire/NewAffaire.vue
+++ b/front/src/components/Affaires/NewAffaire/NewAffaire.vue
@@ -407,7 +407,7 @@ export default {
               }
               if (this.selectedAnciensNumeros.length === this.affaire_numeros_anciens.length && this.selectedNouveauxNumeros.length === this.affaire_numeros_nouveaux.length) {
                 // Si tous les numéros sont sélectionnés, clôre l'affaire de base !
-                promises.push(this.cloreAffaireBase());
+                promises.push(this.cloreAffaireBase(id_new_affaire));
               }
               if (this.form.affaire_modif_type.id === this.typesAffaires_conf.modification_abandon_partiel) {
                 // supprimer les bf référencés à l'affaire
@@ -638,20 +638,23 @@ export default {
      * Affaire de modification: tous les numéros sont récupérés par l'affaire fille:
      * cloturer l'affaire de base
      */
-    async cloreAffaireBase() {
+    async cloreAffaireBase(new_affaire_id) {
       let formData = new FormData();
-      formData.append("id_affaire", this.form.affaire_base_id);
-      formData.append("date_cloture", moment(new Date()).format(process.env.VUE_APP_DATEFORMAT_WS));
-      
+      formData.append('affaire_id', this.form.affaire_base_id);
+      formData.append('remarque', "L'affaire a été clôturée avec l'ouverture de l'affaire de modification " + new_affaire_id);
+
       return new Promise((resolve, reject) => {
-        this.$http.put(
-          process.env.VUE_APP_API_URL + process.env.VUE_APP_AFFAIRES_ENDPOINT,
+        this.$http.post(
+          process.env.VUE_APP_API_URL + process.env.VUE_APP_AFFAIRE_CLOTURE_ENDPOINT,
           formData,
           {
             withCredentials: true,
             headers: {Accept: "application/json"}
           }
-        ).then(response => resolve(response))
+        ).then((response) => {
+          this.$root.$emit('ShowMessage', "L'affaire de base a bien été clôturée");
+          resolve(response);
+        })
         .catch(err => reject(err));
       });
     },


### PR DESCRIPTION
corrige un problème qui effaçait le texte "description de l'affaire" lors de la sélection de l'affaire de base dans le cas d'une modification d'affaire.
permet de sélectionner une affaire de servitude clôturée pour la modifier (comme elle est clôturée d'office lors de l'envoi)
