### PR TITLE
Supprimer un bien-fonds réservé

### DIFF
--- a/back/infolica/exceptions/custom_error.py
+++ b/back/infolica/exceptions/custom_error.py
@@ -10,6 +10,7 @@ class CustomError(Exception):
     NOT_FOUND_ERROR = "Route {} with method {} not found"
     RESERVATION_NUMBER_WITHOUT_BASE_NUMBER = "Manque le numéro de base lors de la réservation de numéros de DDP, PPE ou PCOP"
     FILE_NOT_FOUND = "Le fichier '{}' n'a pas été trouvé"
-    DIRECTORY_WRONG_BASE = "Le dossier '{}' n'a pas la bonne base ({})" 
+    DIRECTORY_WRONG_BASE = "Le dossier '{}' n'a pas la bonne base ({})"
     DIRECTORY_NOT_FOUND = "Le dossier '{}' n'existe pas"
     NUMBER_REGISTRATION_FAILED = "Le numéro {} du cadastre {} dépasse le max + 1 autorisé (dernier numéro: {})"
+    SENT_AFFAIRE_EXCEPTION = "L'opération n'a pas pu être exécutée, car l'affaire {} est déjà envoyée"

--- a/back/infolica/routes.py
+++ b/back/infolica/routes.py
@@ -104,6 +104,7 @@ def includeme(config):
     # config.add_route('numeros_relations_by_numeroBase_s','/infolica/api/numeros_relations_by_numeroBase_id/')
     config.add_route('numeros_differes','/infolica/api/numeros_differes')
     config.add_route('numeros_differes_s','/infolica/api/numeros_differes/')
+    config.add_route('delete_numero','/infolica/api/delete_numero/{id}')
     #Référence de numéros
     config.add_route('reference_numeros','/infolica/api/reference_numeros')
     config.add_route('reference_numeros_s','/infolica/api/reference_numeros/')

--- a/back/infolica/views/default.py
+++ b/back/infolica/views/default.py
@@ -60,6 +60,7 @@ def test_error(exc, request):
 @view_config(route_name='courrier_retablissement_pfp', request_method='OPTIONS', renderer='json')
 @view_config(route_name='delete_affaire_document', request_method='OPTIONS', renderer='json')
 @view_config(route_name='numeros', request_method='OPTIONS', renderer='json')
+@view_config(route_name='delete_numero', request_method='OPTIONS', renderer='json')
 @view_config(route_name='numeros_s', request_method='OPTIONS', renderer='json')
 @view_config(route_name='numeros_relations', request_method='OPTIONS', renderer='json')
 @view_config(route_name='numeros_relations_s', request_method='OPTIONS', renderer='json')

--- a/back/infolica/views/numero.py
+++ b/back/infolica/views/numero.py
@@ -240,6 +240,16 @@ def numeros_delete_view(request):
     if aff.date_envoi is not None:
         raise CustomError(CustomError.SENT_AFFAIRE_EXCEPTION.format(affaire_id))
 
+    # make sure that bf to delete is reserved in current affaire
+    check_reserved_bf = request.dbsession.query(AffaireNumero).filter(
+        AffaireNumero.numero_id==numero_id,
+        AffaireNumero.affaire_id==affaire_id,
+        AffaireNumero.type_id==request.registry.settings['affaire_numero_type_nouveau_id'],
+    ).first()
+    if check_reserved_bf is None:
+        raise CustomError(f"Impossible de supprimer le numéro {numero_id}, il ne figure pas dans la liste des biens-fonds réservés pour l'affaire {affaire_id}")
+
+
     # get numero_relation and remove it
     nr = request.dbsession.query(NumeroRelation).filter(
         NumeroRelation.numero_id_associe==numero_id,

--- a/front/.env
+++ b/front/.env
@@ -66,6 +66,7 @@ VUE_APP_NUMEROS_RELATIONS_BY_AFFAIREID_ENDPOINT = "/affaire_numeros_relations/"
 VUE_APP_NUMEROS_DDP_ENDPOINT = "/new_ddp"
 #VUE_APP_NUMEROS_RELATIONS_BY_NUMEROSBASEID_ENDPOINT = "/numeros_relations_by_numeroBase_id"
 VUE_APP_NUMEROS_DIFFERES_ENDPOINT = "/numeros_differes"
+VUE_APP_DELETE_NUMERO_ENDPOINT = "/delete_numero/"
 
 #Réservation_numéros
 VUE_APP_REFERENCE_NUMEROS_ENDPOINT = "/reference_numeros/"

--- a/front/src/components/Affaires/NumerosAffaire/NumerosAffaire.vue
+++ b/front/src/components/Affaires/NumerosAffaire/NumerosAffaire.vue
@@ -408,10 +408,10 @@ export default {
     //   return new Promise((resolve, reject) => {
     //     // Récupère la liste des id des numéros référencés
     //     let numeros_base_id_list = this.affaire_numeros_anciens.map(x => x.numero_id);
-  
+
     //     let formData = new FormData();
     //     formData.append("numeros_base_id_list", JSON.stringify(numeros_base_id_list));
-  
+
     //     this.$http.post(
     //       process.env.VUE_APP_API_URL +
     //       process.env.VUE_APP_NUMEROS_RELATIONS_BY_NUMEROSBASEID_ENDPOINT,
@@ -505,15 +505,15 @@ export default {
         this.typesAffaires_conf.modification_ppe,
         this.typesAffaires_conf.modification_retour_etat_juridique,
       ];
-      
+
       this.show = {
         numeros_reserves_card: typeAffaire_modification_all.concat([
-          this.typesAffaires_conf.mutation, 
-          this.typesAffaires_conf.ppe, 
+          this.typesAffaires_conf.mutation,
+          this.typesAffaires_conf.ppe,
           this.typesAffaires_conf.pcop,
           this.typesAffaires_conf.remaniement_parcellaire
         ]).includes(this.affaire.type_id),
-        
+
         numeros_references_card: [
           this.typesAffaires_conf.cadastration,
           this.typesAffaires_conf.pcop,
@@ -536,7 +536,7 @@ export default {
         ].includes(this.affaire.type_id),
 
         reservation_numeros_mo: [
-          this.typesAffaires_conf.mutation, 
+          this.typesAffaires_conf.mutation,
           this.typesAffaires_conf.autre,
           this.typesAffaires_conf.cadastration,
           this.typesAffaires_conf.revision_abornement,
@@ -563,8 +563,8 @@ export default {
           this.typesAffaires_conf.mpd,
           this.typesAffaires_conf.modification_abandon_partiel
         ].includes(this.affaire.type_id)
-          && role_id && !isNaN(role_id) && Number(process.env.VUE_APP_ADMIN_ROLE_ID) === Number(role_id),
-        
+          && role_id && !isNaN(role_id),
+
         updateReferencedNumberBtn: [
           this.typesAffaires_conf.ppe,
           this.typesAffaires_conf.pcop
@@ -603,7 +603,7 @@ export default {
 
 
     /**
-     * Fonction appelée lorsque des numéros sont référencés à l'affaire 
+     * Fonction appelée lorsque des numéros sont référencés à l'affaire
      */
     async saveReferenceNumeros(numeros) {
       let numeros_ = numeros.map(x => ({
@@ -635,7 +635,7 @@ export default {
 
 
     /**
-     * Fonction appelée lorsque des numéros référencés sont modifiés 
+     * Fonction appelée lorsque des numéros référencés sont modifiés
      */
     async saveModifReferenceNumeros(data) {
       let formData = new FormData();
@@ -678,12 +678,12 @@ export default {
           content: "Le numéro " + item.numero + " du cadastre de " + item.numero_cadastre + " est utilisé comme bien-fonds de base pour des numéros dans cette affaire."
         });
       } else {
-        
+
         let content = "Confirmer la suppression du lien entre le numéro "  + item.numero + " du cadastre de " + item.numero_cadastre + " et l'affaire " + this.affaire.id + "."
         if (this.affaire.type_id === this.typesAffaires_conf.cadastration) {
           content += " Les factures liées à ce numéro seront également supprimée automatiquement."
         }
-        
+
         this.$root.$emit("ShowConfirmation", {
           title: "Demande de confirmation",
           content: content,
@@ -713,8 +713,8 @@ export default {
         }
       }).catch(err => handleException(err, this));
     },
-    
-    
+
+
     /**
      * Modifier numéro de base (PPE/PCOP)
      */
@@ -731,7 +731,7 @@ export default {
       return false;
     },
 
-    
+
     async saveNumerosFromExcel_remaniementParcellaire(data){
       let formData = new FormData();
       formData.append('affaire_id', this.affaire.id);
@@ -766,7 +766,7 @@ export default {
       let file = document.getElementById('inputFile').files[0];
       let test = this.checkFile(file, '.xlsx');
       let allowConfirm = true;
-      
+
       if(test===false){
         return;
       }
@@ -785,7 +785,7 @@ export default {
         )
         .then(response => {
           let content = "";
-          
+
           response.data.forEach(x => {
             // source Infolica or Terris
             content += "<h3>" + x.source + "</h3>";
@@ -795,7 +795,7 @@ export default {
                 content += "<tr>";
                 content += "<td style='width: 100px;'>" + y.cadastre + "</td>";
                 content += "<td style='width: 1000px;'>"
-                
+
                 let sep = '';
                 y.liste_numeros.forEach(z => {
                   // parcourir liste_numeros
@@ -809,10 +809,10 @@ export default {
                 content += "<tr>";
               });
             content += "</tbody></table>";
-            
+
           });
           content += "<p style='font-style: italic;'>Les numéros de biens-fonds en <span style='color: green;'>vert</span> sont ceux qui ont déjà été réservés dans l'affaire, ceux en <span style='color: blue;'>bleu</span> ont été réservés dans une autre affaire et ceux en <span style='color: red;'>rouge</span> seront créés en cliquant sur 'confimer'.</p>";
-          
+
           if (allowConfirm) {
             this.confirmDialog= {
               show: true,
@@ -822,7 +822,7 @@ export default {
             };
           } else {
             content += "<p style='font-weight: bold; color: blue;'>Les numéros réservés dans une autre affaire ou les DDP doivent être manuellement supprimés dans le fichier Excel afin de valider le processus.</p>";
-            
+
             this.alertDialog= {
               show: true,
               title: 'Biens-fonds chargés',
@@ -852,7 +852,35 @@ export default {
         onConfirm: () => { this.onConfirmLoadNumerosFromExcel_remaniementParcellaire() }
       };
 
-    }
+    },
+
+    // confirm delete reserved number
+    confirmDeleteReservedNumber(item) {
+      this.confirmDialog = {
+        show: true,
+        title: "Confirmer la suppression d'un numéro de bien-fonds",
+        content: `En cliquant sur "confirmer", le bien-fonds ${item.numero} (cadastre: ${item.numero_cadastre}) sera définitivement supprimé.`,
+        onConfirm: () => this.deleteReservedNumber(item),
+      }
+    },
+
+    // delete reserved number
+    async deleteReservedNumber(item) {
+      this.numerosLoading = true;
+      this.$http.delete(process.env.VUE_APP_API_URL + process.env.VUE_APP_DELETE_NUMERO_ENDPOINT + item.numero_id + "?affaire_id=" + this.affaire.id,
+        {
+          withCredentials: true,
+          headers: { Accept: "application/json" }
+        }
+      ).then(() => {
+        this.$root.$emit("ShowMessage", "Le bien-fonds a été correctement supprimé.")
+        this.$root.$emit("searchAffaireNumeros");
+      }).catch(err => {
+        handleException(err, this);
+      }).finally(() => {
+        this.numerosLoading = false;
+      });
+    },
 
 
   },

--- a/front/src/components/Affaires/NumerosAffaire/numerosAffaire.html
+++ b/front/src/components/Affaires/NumerosAffaire/numerosAffaire.html
@@ -20,10 +20,10 @@
                             <md-button class="md-raised md-primary" v-on:click="loadNumerosFromExcel_remaniementParcellaire"><md-icon>description</md-icon> Importer les numéros de biens-fonds depuis le fichier excel</md-button>
                             <md-progress-bar md-mode="indeterminate" v-if="numerosLoading"></md-progress-bar>
                         </div>
-                        
+
                         <!-- NUMEROS VALIDES CONCERNES (anciens numéros) -->
                         <div class="md-layout-item md-size-45" v-if="show.numeros_references_card || affaire_numeros_anciens.length > 0">
-                    
+
                             <md-card>
                                 <md-card-header>
                                     <div class="justifyTitleBtn">
@@ -62,14 +62,14 @@
                                 </md-card-content>
                             </md-card>
                         </div>
-                        
+
                         <!-- NUMEROS RESERVES (nouveaux numéros) -->
-                        <div class="md-layout-item md-size-45" v-if="show.numeros_reserves_card">   
+                        <div class="md-layout-item md-size-45" v-if="show.numeros_reserves_card">
                             <md-card>
                                 <md-card-header>
                                     <div class="justifyTitleBtn">
                                         <div class="md-title">Immeubles réservés</div>
-                                        
+
                                         <div>
                                             <md-button class="md-primary" @click="doQuittanceNumerosReserves" v-if="affaire_numeros_nouveaux.length > 0">Quittance</md-button>
                                             <md-button class="md-primary" @click="callOpenQuittancePCOPDialog" v-if="affaire.type_id === typesAffaires_conf.pcop && affaire_numeros_nouveaux.length > 0">Quittance PCOP</md-button>
@@ -77,7 +77,7 @@
                                         </div>
                                     </div>
                                 </md-card-header>
-                                
+
                                 <md-card-content>
                                     <!-- Tableau des numéros réservés dans l'affaire -->
                                     <div v-if="affaire_numeros_nouveaux[0]">
@@ -98,7 +98,7 @@
                                                 <md-table-cell md-label="Mat diff" class="actionsColumn" v-if="typesAffaires_conf.mutation === affaire.type_id || affaire.type_id === typesAffaires_conf.modification_mutation">
                                                     <!-- Si le numéro est différé -->
                                                     <div v-if="item.numero_diff_entree && item.numero_diff_sortie === null && editMatDiffAllowed">
-                                                        <md-button v-if="item.numero_type_id===types_numeros.bf || item.numero_type_id===types_numeros.ddp"  @click="confirmCreateDiffererNumero(item, 'sortie')" 
+                                                        <md-button v-if="item.numero_type_id===types_numeros.bf || item.numero_type_id===types_numeros.ddp"  @click="confirmCreateDiffererNumero(item, 'sortie')"
                                                             class="md-accent md-raised md-icon-button md-dense" title="Retirer la mention Mat Diff du BF (le BF est matérialisé)">
                                                             <md-icon>access_time</md-icon>
                                                         </md-button>
@@ -118,72 +118,78 @@
                                                         </md-button>
                                                     </div>
                                                 </md-table-cell>
+                                                <md-table-cell md-label="Supprimer " class="removecolumn">
+                                                    <md-button v-if="affaire.date_envoi === null"  @click="confirmDeleteReservedNumber(item)"
+                                                        class="md-accent  md-icon-button md-dense" title="Supprimer le bien-fonds réservé">
+                                                        <md-icon>delete</md-icon>
+                                                    </md-button>
+                                                </md-table-cell>
                                             </md-table-row>
                                         </md-table>
                                     </div>
                                     <div v-else>
                                         <em>Aucun numéro</em>
                                     </div>
-                                    
+
                                 </md-card-content>
                             </md-card>
-        
-            
+
+
                         </div>
                     </div>
-                    
-                    
-                    <div class="md-layout md-gutter">    
+
+
+                    <div class="md-layout md-gutter">
                         <div class="md-layout-item md-size-60" v-if="show.reservation_numeros_mo">
-                            
+
                             <!-- Numéros de la MO -->
                             <ReservationNumerosMO :affaire="affaire" :types_numeros="types_numeros" :permission="permission"></ReservationNumerosMO>
-                            
+
                         </div>
                     </div>
-                    
+
                     <div class="md-layout md-gutter">
                         <div class="md-layout-item" v-if="show.balance">
                             <!-- Balance des biens-fonds -->
-                            <BalanceFromFile :numeros_nouveaux_bk="affaire_numeros_nouveaux" 
-                                :numeros_anciens_bk="affaire_numeros_anciens" 
-                                :affaire="affaire" 
-                                :types_numeros="types_numeros" 
-                                :numerosBaseListe="numerosBaseListe" 
+                            <BalanceFromFile :numeros_nouveaux_bk="affaire_numeros_nouveaux"
+                                :numeros_anciens_bk="affaire_numeros_anciens"
+                                :affaire="affaire"
+                                :types_numeros="types_numeros"
+                                :numerosBaseListe="numerosBaseListe"
                                 :etatNumeros_conf="etatNumeros_conf" />
                         </div>
                     </div>
-                    
+
                     </md-card-content>
             </md-card-expand-content>
         </md-card-expand>
     </md-card>
 
     <!-- Référence de numéros -->
-    <ReferenceNumeros ref="formReference" 
+    <ReferenceNumeros ref="formReference"
                       id="test1"
                       :affaire_numeros_anciens="affaire_numeros_anciens"
                       :cadastre_id="affaire.cadastre_id"
                       :saveNumerosReferences="saveReferenceNumeros" />
-    
-    <ReferenceNumeros ref="formModifReference" 
+
+    <ReferenceNumeros ref="formModifReference"
                       id="test2"
                       dialogTitle="test"
                       selectionType="single"
                       :affaire_numeros_anciens="affaire_numeros_anciens"
                       :cadastre_id="affaire.cadastre_id"
                       :saveNumerosReferences="saveModifReferenceNumeros" />
-    
+
     <!-- Réservation de numéros -->
     <ReservationNumeros ref="formReservation"
-                        :affaire="affaire" 
-                        :numerosBaseListe="affaire_numeros_anciens" 
+                        :affaire="affaire"
+                        :numerosBaseListe="affaire_numeros_anciens"
                         :typesAffaires_conf="typesAffaires_conf"
                         :types_numeros="types_numeros" />
 
     <!-- Quittance pour les numéros de parts de copropriété réservés -->
-    <QuittancePCOP :affaire="affaire" 
-                   :affaire_numeros_anciens="affaire_numeros_anciens" 
+    <QuittancePCOP :affaire="affaire"
+                   :affaire_numeros_anciens="affaire_numeros_anciens"
                    :affaire_numeros_nouveaux="affaire_numeros_nouveaux"
                    ref="formQuittancePCOP"/>
 

--- a/front/src/components/Clients/ClientsEdit.vue
+++ b/front/src/components/Clients/ClientsEdit.vue
@@ -506,7 +506,6 @@ export default {
         }
       ).then((response) => {
         if (response && response.data) {
-          console.log('response.data',response.data)
           this.existingClient = response.data;
         }
       }).catch(err => handleException(err, this));


### PR DESCRIPTION
Une fois qu'un bien-fonds est réservé, il n'est pas possible pour l'utilisateur de le supprimer. Ce PR rajoute un bouton qui permet cette opération. Les biens-fonds réservée peuvent être réservés uniquement si l'affaire n'a pas encore de date d'envoi.