### PR TITLE
Allows balance to be saved even if new parcels are not referenced in affaire, but by linking them on the fly

### DIFF
--- a/back/infolica/routes.py
+++ b/back/infolica/routes.py
@@ -119,6 +119,7 @@ def includeme(config):
     config.add_route('affaire_numeros_MO_by_affaire_id', '/infolica/api/numeros_mo_affaire/{id}')
     config.add_route('desactiver_numeros_affaires','/infolica/api/desactiver_numeros_affaires')
     config.add_route('desactiver_numeros_affaires_s','/infolica/api/desactiver_numeros_affaires/')
+    config.add_route('add_affaire_numero','/infolica/api/add_affaire_numero')
     #Historique numéros
     config.add_route('numeros_etat_histo','/infolica/api/numeros_etat_histo')
     config.add_route('numeros_etat_histo_s','/infolica/api/numeros_etat_histo/')

--- a/front/.env
+++ b/front/.env
@@ -67,6 +67,7 @@ VUE_APP_NUMEROS_DDP_ENDPOINT = "/new_ddp"
 #VUE_APP_NUMEROS_RELATIONS_BY_NUMEROSBASEID_ENDPOINT = "/numeros_relations_by_numeroBase_id"
 VUE_APP_NUMEROS_DIFFERES_ENDPOINT = "/numeros_differes"
 VUE_APP_DELETE_NUMERO_ENDPOINT = "/delete_numero/"
+VUE_APP_ADD_AFFAIRE_NUMERO_ENDPOINT = "/add_affaire_numero"
 
 #Réservation_numéros
 VUE_APP_REFERENCE_NUMEROS_ENDPOINT = "/reference_numeros/"

--- a/front/src/components/Affaires/BalanceFromFile/balanceFromFile.html
+++ b/front/src/components/Affaires/BalanceFromFile/balanceFromFile.html
@@ -201,4 +201,14 @@
         :md-title="alertDialog.title"
         :md-content="alertDialog.content" />
 
+    <!-- Custom Confirm dialog -->
+    <md-dialog-confirm
+        :md-active.sync="confirmDialog.show"
+        :md-title=confirmDialog.title
+        :md-content=confirmDialog.content
+        :md-confirm-text=confirmDialog.confirmButton
+        :md-cancel-text=confirmDialog.cancelButton
+        @md-cancel="confirmDialog.onCancel"
+        @md-confirm="confirmDialog.onConfirm" />
+
 </div>


### PR DESCRIPTION
Sous certaines conditions, permet d'enregistrer une balance même quand les nouveaux biens-fonds de l'affaire ne sont pas encore référencés à l'affaire (ou pas encore créés). Après confirmation de l'opérateur, les biens-fonds sont créés si nécessaire et liés à l'affaire. Ensuite l'opérateur peut enregistrer la balance.